### PR TITLE
Last steps for reqScannerSubscription

### DIFF
--- a/client.js
+++ b/client.js
@@ -1770,7 +1770,10 @@ class Client {
         scannerSubscriptionFilterOptions:TagValueList
     */
 
-
+    let requestId = await this._allocateRequestId();
+    let subscription = p.subscription
+    let scannerSubscriptionFilterOptions = p.scannerSubscriptionFilterOptions
+    let scannerSubscriptionOptions = p.scannerSubscriptionOptions
 
     if (this._serverVersion < ServerVersion.MIN_SERVER_VER_SCANNER_GENERIC_OPTS &&
           cannerSubscriptionFilterOptions != null) {

--- a/income-fieldset-handlers/index.js
+++ b/income-fieldset-handlers/index.js
@@ -325,8 +325,10 @@ export default {
     let items = [];
 
     for (let n = 0; n < numberOfElements; n++) {
-      item = {
-        contractDetails: {},
+      let item = {
+        contractDetails: {
+          contract: {}
+        },
         rank: parseInt(fields.shift())
       };
 
@@ -334,7 +336,7 @@ export default {
       item.contractDetails.contract.symbol = fields.shift();
       item.contractDetails.contract.secType = fields.shift();
       item.contractDetails.contract.lastTradeDateOrContractMonth = fields.shift();
-      item.contractDetails.contract.strike = decode(float, fields)
+      item.contractDetails.contract.strike = parseFloat(fields.shift());
       item.contractDetails.contract.right = fields.shift();
       item.contractDetails.contract.exchange = fields.shift();
       item.contractDetails.contract.currency = fields.shift();

--- a/income-fieldset-handlers/index.js
+++ b/income-fieldset-handlers/index.js
@@ -351,6 +351,8 @@ export default {
     }
 
     this.requestIdResolve(requestId, items);
+
+    this.requestIdEmit(requestId, 'tick', items);
   },
 
 

--- a/income-fieldset-handlers/index.js
+++ b/income-fieldset-handlers/index.js
@@ -350,6 +350,7 @@ export default {
       items.push(item);
     }
 
+    this.requestIdEmit(requestId, 'tick', items);
   },
 
 

--- a/income-fieldset-handlers/index.js
+++ b/income-fieldset-handlers/index.js
@@ -350,9 +350,6 @@ export default {
       items.push(item);
     }
 
-    this.requestIdResolve(requestId, items);
-
-    this.requestIdEmit(requestId, 'tick', items);
   },
 
 


### PR DESCRIPTION
Small fixes to have `reqScannerSubscription` available.
You already did all the work, just small changes.

Example of use:

```
        let e = await this.api.reqScannerSubscription({
            subscription: {
                instrument: 'STK',
                scanCode: 'TOP_PERC_GAIN',
            },
            scannerSubscriptionOptions: [],
            scannerSubscriptionFilterOptions: [],
        })

    e.on('tick', (t) => {
        console.log(t);
    });
```

Example of the response:
```
[
  {
    "contractDetails": {
      "contract": {
        "conId": 288866386,
        "symbol": "HLWD",
        "secType": "STK",
        "lastTradeDateOrContractMonth": "",
        "strike": 0,
        "right": "",
        "exchange": "SMART",
        "currency": "USD",
        "localSymbol": "HLWD",
        "tradingClass": "NOINFO"
      },
      "marketName": "NOINFO"
    },
    "rank": 0,
    "distance": "",
    "benchmark": "",
    "projection": "",
    "legsStr": ""
  },
...
```

