### PR TITLE
Fix undefined variable in decodeComboLegs

### DIFF
--- a/income-fieldset-handlers/order.js
+++ b/income-fieldset-handlers/order.js
@@ -385,7 +385,7 @@ class OrderDecoder {
         this.contract.comboLegs = [];
 
         for (let n = 0; n < comboLegsCount; n++) {
-            comboLeg = {};
+            const comboLeg = {};
             comboLeg.conId = this._shiftInt();
             comboLeg.ratio = this._shiftInt();
             comboLeg.action = this._shift();


### PR DESCRIPTION
I noticed this while running the [order](https://github.com/maxicus/ib-tws-api/blob/master/examples/order.js) example. My TWS had some open orders for combos, and `getAllOpenOrders` received them.