### PR TITLE
Add createCombo method and example. Fix #20.

### DIFF
--- a/examples/create-combo.js
+++ b/examples/create-combo.js
@@ -1,0 +1,27 @@
+import { Client, Contract } from '../index.js';
+
+const api = new Client({
+  host: '127.0.0.1',
+  port: 7496,
+});
+
+
+
+try {
+  const put = Contract.option({
+    symbol: 'GOOG',
+    lastTradeDateOrContractMonth: '20230616',
+    strike: 2700,
+    right: 'P',
+  });
+  const call = { ...put, right: 'C' };
+  const straddle = await api.createCombo([
+    [1, put],
+    [1, call],
+  ]);
+  console.log('Straddle:', straddle);
+  process.exit(0);
+} catch (e) {
+  console.error('ERROR:', e.message);
+  process.exit(1);
+}


### PR DESCRIPTION
Since @maxicus [mentioned](https://github.com/maxicus/ib-tws-api/pull/21#pullrequestreview-735905893) he used combos all the time, I've added a `createCombo` method to simply combo creation.

The example has been tested to work beyond creating the combo. For example, getHistoricalData BID_ASK does obtain correct data for the combo.