### PR TITLE
Add timezone to dates used in examples

### DIFF
--- a/examples/historical-data.js
+++ b/examples/historical-data.js
@@ -10,7 +10,7 @@ async function run() {
 
   let details = await api.getHistoricalData({
     contract: Contract.stock('AAPL'),
-    endDateTime: '20200308 12:00:00',
+    endDateTime: '20200308 12:00:00 US/Eastern',
     duration: '1 D',
     barSizeSetting: '1 min',
     whatToShow: 'TRADES',

--- a/examples/historical-ticks.js
+++ b/examples/historical-ticks.js
@@ -10,7 +10,7 @@ async function run() {
 
   let details = await api.getHistoricalTicks({
     contract: Contract.stock('AAPL'),
-    startDateTime: '20200608 11:00:00',
+    startDateTime: '20200608 11:00:00 US/Eastern',
     numberOfTicks: 1000,
     whatToShow: 'TRADES',
     useRth: 1


### PR DESCRIPTION
Fixes https://github.com/maxicus/ib-tws-api/issues/29

Examples have been updated with the new date format which is required on newer IB API versions.